### PR TITLE
Added simply history features

### DIFF
--- a/src/CLI.cpp
+++ b/src/CLI.cpp
@@ -42,6 +42,10 @@ namespace zmq = opentxs::network::zeromq;
 #define RPC_COMMAND_VERSION 2
 #define SENDPAYMENT_VERSION 1
 
+const std::string HISTORY = {"history"};
+const std::string WRITE_HISTORY = {"write_history"};
+const std::string READ_HISTORY = {"read_history"};
+
 namespace opentxs::otctl
 {
 const std::map<std::string, proto::RPCCommandType> CLI::commands_{
@@ -2282,16 +2286,47 @@ int CLI::Run()
         if (input[0] == '#') continue;
 
         auto first = input.substr(0, input.find(" "));
-        if ("history_write" == first) {
-            std::string partial = input.substr(12, std::string::npos);
+        if ("quit" == first) { break; }
+
+        if (READ_HISTORY == first) {
+            std::string partial =
+                input.substr(READ_HISTORY.size(), std::string::npos);
             ::trim(partial);
+            if (partial.size() == 0) {
+                std::cerr << READ_HISTORY << " requires a valid filename."
+                          << std::endl;
+                continue;
+            }
+            struct passwd* pw = getpwuid(getuid());
+            const char* homedir = pw->pw_dir;
+            partial = partial.insert(0, "/").insert(0, homedir);
+            std::ifstream myfile(partial, std::ios::in | std::ios::app);
+            if (myfile.is_open()) {
+                std::string line;
+                while (std::getline(myfile, line)) { history.push_back(line); }
+                myfile.close();
+                std::cout << "File read into history: " + partial << std::endl;
+            } else
+                std::cerr << "Couldn't read history from file " << partial
+                          << std::endl;
+            continue;
+        } else if (WRITE_HISTORY == first) {
+            std::string partial =
+                input.substr(WRITE_HISTORY.size(), std::string::npos);
+            ::trim(partial);
+            if (partial.size() == 0) {
+                std::cerr << WRITE_HISTORY << " requires a valid filename."
+                          << std::endl;
+                continue;
+            }
             struct passwd* pw = getpwuid(getuid());
             const char* homedir = pw->pw_dir;
             partial = partial.insert(0, "/").insert(0, homedir);
             std::ofstream myfile(partial, std::ios::out | std::ios::app);
             if (myfile.is_open()) {
                 std::time_t result = std::time(nullptr);
-                myfile << "\n# history_dump on" << std::ctime(&result) << "\n";
+                myfile << "\n# " << WRITE_HISTORY << " on "
+                       << std::ctime(&result) << "\n";
                 for (std::string line : history) myfile << line << "\n";
                 myfile.close();
                 std::cout << "File written to: " + partial << std::endl;
@@ -2299,9 +2334,10 @@ int CLI::Run()
                 std::cerr << "Couldn't write history to file " << partial
                           << std::endl;
             continue;
-        } else if ("history" == first) {
+        } else if (HISTORY == first) {
 
-            std::string partial = input.substr(7, std::string::npos);
+            std::string partial =
+                input.substr(HISTORY.size(), std::string::npos);
             ::trim(partial);
             if (partial.empty() /*list history*/) {
                 int i = 0;
@@ -2311,6 +2347,20 @@ int CLI::Run()
                 continue;
             } else /* use history */
             {
+                // check for history range execution
+                std::size_t pos = partial.find("-");
+                if (pos != std::string::npos) {
+                    unsigned long start = std::stoul(partial);
+                    unsigned long end = 1 + std::stoul(partial.substr(1 + pos));
+                    for (unsigned long x = start; x < end; x++) {
+                        input = history[x];
+                        first = input.substr(0, input.find(" "));
+                        std::cout << "Using history " << x << ": " + input
+                                  << std::endl;
+                        execute(first, input);
+                    }
+                    continue;
+                }
                 unsigned long history_index = std::stoul(partial);
                 if (history_index < history.size()) {
                     input = history[history_index];
@@ -2326,20 +2376,26 @@ int CLI::Run()
         }
         history.push_back(input);
 
-        if ("quit" == first) { break; }
-
-        try {
-            const auto command = commands_.at(first);
-            const auto& processor = *processors_.at(command);
-            processor(input, socket_);
-        } catch (po::error& err) {
-            LogOutput("Error processing command: ")(err.what()).Flush();
-        } catch (...) {
-            LogOutput("Unknown command").Flush();
-        }
+        execute(first, input);
     }
 
     return 0;
+}
+
+void CLI::execute(std::string cmd, std::string arguments)
+{
+    try {
+        using namespace std::chrono_literals;
+        const auto command = commands_.at(cmd);
+        const auto& processor = *processors_.at(command);
+        processor(arguments, socket_);
+        std::cerr << std::endl;           // flush the stream
+        std::this_thread::sleep_for(1s);  // wait for process output/cerr
+    } catch (po::error& err) {
+        LogOutput("Error processing command: ")(err.what()).Flush();
+    } catch (...) {
+        LogOutput("Unknown command").Flush();
+    }
 }
 
 bool CLI::send_message(

--- a/src/CLI.hpp
+++ b/src/CLI.hpp
@@ -14,200 +14,279 @@
 
 namespace po = boost::program_options;
 
-namespace opentxs::otctl
-{
-class CLI
-{
-public:
-    CLI(const api::Native& ot, const po::variables_map& options);
+namespace opentxs::otctl {
+    class CLI {
+    public:
+        CLI(const api::Native &ot, const po::variables_map &options);
 
-    int Run();
+        int Run();
 
-    ~CLI() = default;
+        ~CLI() = default;
 
-private:
-    using PushHandler = void (*)(const proto::RPCPush&);
-    using ResponseHandler = void (*)(const proto::RPCResponse&);
-    using Processor =
-        void (*)(const std::string&, const network::zeromq::DealerSocket&);
+    private:
+        using PushHandler = void (*)(const proto::RPCPush &);
+        using ResponseHandler = void (*)(const proto::RPCResponse &);
+        using Processor =
+        void (*)(const std::string &, const network::zeromq::DealerSocket &);
 
-    static const std::map<std::string, proto::RPCCommandType> commands_;
-    static const std::map<proto::RPCPushType, PushHandler> push_handlers_;
-    static const std::map<proto::RPCCommandType, ResponseHandler>
-        response_handlers_;
-    static const std::map<proto::RPCCommandType, Processor> processors_;
-    static const std::map<proto::RPCCommandType, std::string> command_names_;
-    static const std::map<proto::RPCResponseCode, std::string> status_names_;
-    static const std::map<proto::AccountEventType, std::string>
-        account_push_names_;
+        static const std::map<std::string, proto::RPCCommandType> commands_;
+        static const std::map<proto::RPCPushType, PushHandler> push_handlers_;
+        static const std::map<proto::RPCCommandType, ResponseHandler>
+                response_handlers_;
+        static const std::map<proto::RPCCommandType, Processor> processors_;
+        static const std::map<proto::RPCCommandType, std::string> command_names_;
+        static const std::map<proto::RPCResponseCode, std::string> status_names_;
+        static const std::map<proto::AccountEventType, std::string>
+                account_push_names_;
 
-    const po::variables_map& options_;
-    const std::string endpoint_;
-    OTZMQListenCallback callback_;
-    OTZMQDealerSocket socket_;
-    OTZMQListenCallback log_callback_;
-    OTZMQSubscribeSocket log_subscriber_;
+        const po::variables_map &options_;
+        const std::string endpoint_;
+        OTZMQListenCallback callback_;
+        OTZMQDealerSocket socket_;
+        OTZMQListenCallback log_callback_;
+        OTZMQSubscribeSocket log_subscriber_;
 
-    static void accept_pending_payment(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void add_client_session(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void add_contact(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void add_server_session(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void create_account(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void create_compatible_account(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void create_nym(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void create_unit_definition(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_account_activity(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_account_balance(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_compatible_accounts(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_nym(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_pending_payments(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_seed(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_server_contract(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_transaction_data(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void get_workflow(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void import_seed(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void import_server_contract(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void issue_unit_definition(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_accounts(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_client_sessions(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_contacts(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_nyms(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_seeds(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_server_contracts(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_server_sessions(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void list_unit_definitions(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void move_funds(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void register_nym(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void send_cheque(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void send_payment(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
-    static void transfer(
-        const std::string& in,
-        const network::zeromq::DealerSocket& socket);
+        static void accept_pending_payment(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
 
-    static void accept_pending_payment_response(const proto::RPCResponse& in);
-    static void add_contact_response(const proto::RPCResponse& in);
-    static void add_session_response(const proto::RPCResponse& in);
-    static void create_account_response(const proto::RPCResponse& in);
-    static void create_nym_response(const proto::RPCResponse& in);
-    static void create_unit_definition_response(const proto::RPCResponse& in);
-    static void get_account_activity_response(const proto::RPCResponse& in);
-    static void get_account_balance_response(const proto::RPCResponse& in);
-    static void get_compatible_accounts_response(const proto::RPCResponse& in);
-    static void get_nym_response(const proto::RPCResponse& in);
-    static void get_pending_payments_response(const proto::RPCResponse& in);
-    static void get_seed_response(const proto::RPCResponse& in);
-    static void get_transaction_data_response(const proto::RPCResponse& in);
-    static void get_server_contract_response(const proto::RPCResponse& in);
-    static void get_workflow_response(const proto::RPCResponse& in);
-    static void import_seed_response(const proto::RPCResponse& in);
-    static void import_server_contract_response(const proto::RPCResponse& in);
-    static void issue_unit_definition_response(const proto::RPCResponse& in);
-    static void list_accounts_response(const proto::RPCResponse& in);
-    static void list_contacts_response(const proto::RPCResponse& in);
-    static void list_nyms_response(const proto::RPCResponse& in);
-    static void list_seeds_response(const proto::RPCResponse& in);
-    static void list_servers_response(const proto::RPCResponse& in);
-    static void list_session_response(const proto::RPCResponse& in);
-    static void list_unit_definitions_response(const proto::RPCResponse& in);
-    static void move_funds_response(const proto::RPCResponse& in);
-    static void register_nym_response(const proto::RPCResponse& in);
-    static void send_payment_response(const proto::RPCResponse& in);
+        static void add_client_session(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
 
-    static void account_event_push(const proto::RPCPush& in);
-    static std::string find_home();
-    static std::string get_account_push_name(
-        const proto::AccountEventType type);
-    static std::string get_command_name(const proto::RPCCommandType type);
-    static std::string get_json(const po::variables_map& cli);
-    static std::string get_socket_path(const po::variables_map& cli);
-    static std::string get_status_name(const proto::RPCResponseCode code);
-    static bool parse_command(
-        const std::string& input,
-        po::options_description& options);
-    static void print_options_description(po::options_description& options);
-    static void print_basic_info(const proto::RPCPush& in);
-    static void print_basic_info(const proto::RPCResponse& in);
-    static void process_push(network::zeromq::Message& in);
-    static void process_reply(network::zeromq::Message& in);
-    static bool send_message(
-        const network::zeromq::DealerSocket& socket,
-        const proto::RPCCommand command);
-    static void set_keys(
-        const po::variables_map& cli,
-        network::zeromq::DealerSocket& socket);
-    static void task_complete_push(const proto::RPCPush& in);
+        static void add_contact(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
 
-    void callback(network::zeromq::Message& in);
-    void remote_log(network::zeromq::Message& in);
+        static void add_server_session(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
 
-    CLI() = delete;
-    CLI(const CLI&) = delete;
-    CLI(CLI&&) = delete;
-    CLI& operator=(const CLI&) = delete;
-    CLI& operator=(CLI&&) = delete;
-};
+        static void create_account(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void create_compatible_account(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void create_nym(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void create_unit_definition(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        void execute(std::string cmd, std::string arguments);
+
+        static void get_account_activity(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_account_balance(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_compatible_accounts(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_nym(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_pending_payments(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_seed(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_server_contract(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_transaction_data(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void get_workflow(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void import_seed(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void import_server_contract(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void issue_unit_definition(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_accounts(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_client_sessions(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_contacts(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_nyms(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_seeds(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_server_contracts(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_server_sessions(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void list_unit_definitions(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void move_funds(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void register_nym(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void send_cheque(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void send_payment(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void transfer(
+                const std::string &in,
+                const network::zeromq::DealerSocket &socket);
+
+        static void accept_pending_payment_response(const proto::RPCResponse &in);
+
+        static void add_contact_response(const proto::RPCResponse &in);
+
+        static void add_session_response(const proto::RPCResponse &in);
+
+        static void create_account_response(const proto::RPCResponse &in);
+
+        static void create_nym_response(const proto::RPCResponse &in);
+
+        static void create_unit_definition_response(const proto::RPCResponse &in);
+
+        static void get_account_activity_response(const proto::RPCResponse &in);
+
+        static void get_account_balance_response(const proto::RPCResponse &in);
+
+        static void get_compatible_accounts_response(const proto::RPCResponse &in);
+
+        static void get_nym_response(const proto::RPCResponse &in);
+
+        static void get_pending_payments_response(const proto::RPCResponse &in);
+
+        static void get_seed_response(const proto::RPCResponse &in);
+
+        static void get_transaction_data_response(const proto::RPCResponse &in);
+
+        static void get_server_contract_response(const proto::RPCResponse &in);
+
+        static void get_workflow_response(const proto::RPCResponse &in);
+
+        static void import_seed_response(const proto::RPCResponse &in);
+
+        static void import_server_contract_response(const proto::RPCResponse &in);
+
+        static void issue_unit_definition_response(const proto::RPCResponse &in);
+
+        static void list_accounts_response(const proto::RPCResponse &in);
+
+        static void list_contacts_response(const proto::RPCResponse &in);
+
+        static void list_nyms_response(const proto::RPCResponse &in);
+
+        static void list_seeds_response(const proto::RPCResponse &in);
+
+        static void list_servers_response(const proto::RPCResponse &in);
+
+        static void list_session_response(const proto::RPCResponse &in);
+
+        static void list_unit_definitions_response(const proto::RPCResponse &in);
+
+        static void move_funds_response(const proto::RPCResponse &in);
+
+        static void register_nym_response(const proto::RPCResponse &in);
+
+        static void send_payment_response(const proto::RPCResponse &in);
+
+        static void account_event_push(const proto::RPCPush &in);
+
+        static std::string find_home();
+
+        static std::string get_account_push_name(
+                const proto::AccountEventType type);
+
+        static std::string get_command_name(const proto::RPCCommandType type);
+
+        static std::string get_json(const po::variables_map &cli);
+
+        static std::string get_socket_path(const po::variables_map &cli);
+
+        static std::string get_status_name(const proto::RPCResponseCode code);
+
+        static bool parse_command(
+                const std::string &input,
+                po::options_description &options);
+
+        static void print_options_description(po::options_description &options);
+
+        static void print_basic_info(const proto::RPCPush &in);
+
+        static void print_basic_info(const proto::RPCResponse &in);
+
+        static void process_push(network::zeromq::Message &in);
+
+        static void process_reply(network::zeromq::Message &in);
+
+        static bool send_message(
+                const network::zeromq::DealerSocket &socket,
+                const proto::RPCCommand command);
+
+        static void set_keys(
+                const po::variables_map &cli,
+                network::zeromq::DealerSocket &socket);
+
+        static void task_complete_push(const proto::RPCPush &in);
+
+        void callback(network::zeromq::Message &in);
+
+        void remote_log(network::zeromq::Message &in);
+
+        CLI() = delete;
+
+        CLI(const CLI &) = delete;
+
+        CLI(CLI &&) = delete;
+
+        CLI &operator=(const CLI &) = delete;
+
+        CLI &operator=(CLI &&) = delete;
+    };
 }  // namespace opentxs::otctl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(cxx-sources
 
 set(cxx-headers
   "CLI.hpp"
+        util.h
 )
 
 add_executable(${MODULE_NAME}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,26 @@
+//
+// Created by mbiggerstaff on 3/1/19.
+//
+
+#include <algorithm>
+#include <functional>
+#include <cctype>
+#include <locale>
+
+// trim from start (in place)
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(),
+                                    std::not1(std::ptr_fun<int, int>(std::isspace))));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(),
+                         std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s) {
+    ltrim(s);
+    rtrim(s);
+}


### PR DESCRIPTION
- all OT commands that don't start with a # are added to the history (history commands are not added)
- history : list history of commands with an index
- write_history <filename> : write history to ~/<filename>
- read_history <filename> : read history in form ~/<filename>
- history <index> : execute the command at the specified <index> in history
- history <start>-<end> : execute the commands at the specified range from <start> to <end>
